### PR TITLE
Allow React 0.14 versions as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "author": "Maxime Poulin <mpoulin@roux.ca>",
   "license": "MIT",
   "peerDependencies": {
-    "react": ">=0.13.0"
+    "react": "0.13 - 0.14"
   },
   "devDependencies": {
     "babel": "^5.5.6",


### PR DESCRIPTION
This will allow all 0.13.x and 0.14.x stable versions.
