### PR TITLE
Fixed issue when incorrect cca3 given

### DIFF
--- a/lib/react-flags.js
+++ b/lib/react-flags.js
@@ -149,7 +149,8 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  // Get information about a country using the alpha-3 ISO code.
 	  cca3To2: function cca3To2(cca3) {
-	    return (0, _lodashCollectionFind2["default"])(_filterLoaderCca2Cca3WorldCountriesCountriesJson2["default"], { "cca3": cca3 }).cca2 || "_unknown";
+	    var country = (0, _lodashCollectionFind2["default"])(_filterLoaderCca2Cca3WorldCountriesCountriesJson2["default"], { "cca3": cca3 });
+	    return country ? country.cca2 : "_unknown";
 	  },
 
 	  /**

--- a/src/Flag.js
+++ b/src/Flag.js
@@ -65,7 +65,8 @@ export default React.createClass({
 
   // Get information about a country using the alpha-3 ISO code.
   cca3To2(cca3) {
-    return find(countries, {"cca3": cca3}).cca2 || "_unknown";
+    let country = find(countries, {"cca3": cca3});
+    return country ? country.cca2 : "_unknown";
   },
 
   /**


### PR DESCRIPTION
`_.find` returns the matched element, else undefined. Function was causing error in case of incorrect cca3 code.
